### PR TITLE
reporting error (HTTP status) when request to web service wasn't successful

### DIFF
--- a/queryset_client/client.py
+++ b/queryset_client/client.py
@@ -804,7 +804,9 @@ class Client(object):
         s = self._main_client._store
         requests = s["session"]
         serializer = slumber.serialize.Serializer(default=s["format"])
-        return serializer.loads(requests.request(method, request_url).content)
+        req = requests.request(method, request_url)
+        req.raise_for_status()
+        return serializer.loads(req.content)
 
     def schema(self, model_name=None):
         """ receive schema


### PR DESCRIPTION
When the actual request is sent to the web service, original code didn't perform any
checks or further security measures, to verify whether valid data was returned, or a
vailure (authentication/authorization error, etc.) was returend.

With a 1-line fix using python requests 'raise_for_status' this patch results in a
correct behaviour (returning results when HTTP status was OK, returning an error,
in case an error occured).